### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 一个基于MCP协议的服务器，使用Brave API实现网络搜索功能。
 
+<a href="https://glama.ai/mcp/servers/vcwtdnw42n"><img width="380" height="200" src="https://glama.ai/mcp/servers/vcwtdnw42n/badge" alt="MCP2Brave MCP server" /></a>
+
 ## 系统要求
 
 - Python 3.11+


### PR DESCRIPTION
This PR adds a badge for the [MCP2Brave](https://glama.ai/mcp/servers/vcwtdnw42n) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/vcwtdnw42n"><img width="380" height="200" src="https://glama.ai/mcp/servers/vcwtdnw42n/badge" alt="MCP2Brave MCP server" /></a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.